### PR TITLE
Fill auth_user_info in OpenStack v3 auth

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changes in Apache Libcloud in development (3.0.0)
 -------------------------------------------------
 
 Common
-~~~~~~~
+~~~~~~
 
 - Fix ``LIBCLOUD_DEBUG_PRETTY_PRINT_RESPONSE`` functionality and make sure it
   works correctly under Python 3 when ``response.read()`` function returns
@@ -13,6 +13,13 @@ Common
 
   (GITHUB-1430)
   [Tomaz Muraus]
+
+- Make sure ``auth_user_info`` variable on the OpenStack identify connection
+  class is populated when using auth version ``3.x_password`` and
+  ``3.x_oidc_access_token``.
+
+  (GITHUB-1436)
+  [@lln-ijinus, Tomaz Muraus)
 
 Compute
 ~~~~~~~

--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -1050,7 +1050,7 @@ class OpenStackIdentity_3_0_Connection(OpenStackIdentityConnection):
                 self.auth_token_expires = parse_date(expires)
                 # Note: catalog is not returned for unscoped tokens
                 self.urls = body['token'].get('catalog', None)
-                self.auth_user_info = None
+                self.auth_user_info = body['token'].get('user', None)
                 self.auth_user_roles = roles
             except KeyError as e:
                 raise MalformedResponseError('Auth JSON response is \

--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -1490,7 +1490,7 @@ class OpenStackIdentity_3_0_Connection_OIDC_access_token(
                 self.auth_token_expires = parse_date(expires)
                 # Note: catalog is not returned for unscoped tokens
                 self.urls = body['token'].get('catalog', None)
-                self.auth_user_info = None
+                self.auth_user_info = body['token'].get('user', None)
                 self.auth_user_roles = roles
             except KeyError as e:
                 raise MalformedResponseError('Auth JSON response is \

--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -1726,6 +1726,7 @@ def get_class_for_auth_version(auth_version):
     elif auth_version == '3.x_oidc_access_token':
         cls = OpenStackIdentity_3_0_Connection_OIDC_access_token
     else:
-        raise LibcloudError('Unsupported Auth Version requested')
+        raise LibcloudError('Unsupported Auth Version requested: %s' %
+                            (auth_version))
 
     return cls

--- a/libcloud/test/common/test_openstack_identity.py
+++ b/libcloud/test/common/test_openstack_identity.py
@@ -55,7 +55,9 @@ class OpenStackIdentityConnectionTestCase(unittest.TestCase):
             ('1.1', OpenStackMockHttp),
             ('2.0', OpenStack_2_0_MockHttp),
             ('2.0_apikey', OpenStack_2_0_MockHttp),
-            ('2.0_password', OpenStack_2_0_MockHttp)
+            ('2.0_password', OpenStack_2_0_MockHttp),
+            ('3.x_password', OpenStackIdentity_3_0_MockHttp),
+            ('3.x_oidc_access_token', OpenStackIdentity_3_0_MockHttp)
         ]
 
         APPEND = 0
@@ -73,7 +75,9 @@ class OpenStackIdentityConnectionTestCase(unittest.TestCase):
             '1.1': '/v1.1/auth',
             '2.0': '/v2.0/tokens',
             '2.0_apikey': '/v2.0/tokens',
-            '2.0_password': '/v2.0/tokens'
+            '2.0_password': '/v2.0/tokens',
+            '3.x_password': '/v3/auth/tokens',
+            '3.x_oidc_access_token': '/v3/OS-FEDERATION/identity_providers/user_name/protocols/tenant-name/auth',
         }
 
         user_id = OPENSTACK_PARAMS[0]
@@ -90,6 +94,7 @@ class OpenStackIdentityConnectionTestCase(unittest.TestCase):
                 osa = cls(auth_url=auth_url,
                           user_id=user_id,
                           key=key,
+                          tenant_name='tenant-name',
                           parent_conn=connection)
 
                 try:
@@ -104,24 +109,35 @@ class OpenStackIdentityConnectionTestCase(unittest.TestCase):
 
     def test_basic_authentication(self):
         tuples = [
-            ('1.0', OpenStackMockHttp),
-            ('1.1', OpenStackMockHttp),
-            ('2.0', OpenStack_2_0_MockHttp),
-            ('2.0_apikey', OpenStack_2_0_MockHttp),
-            ('2.0_password', OpenStack_2_0_MockHttp)
+            ('1.0', OpenStackMockHttp, {}),
+            ('1.1', OpenStackMockHttp, {}),
+            ('2.0', OpenStack_2_0_MockHttp, {}),
+            ('2.0_apikey', OpenStack_2_0_MockHttp, {}),
+            ('2.0_password', OpenStack_2_0_MockHttp, {}),
+            ('3.x_password', OpenStackIdentity_3_0_MockHttp, {'user_id': 'test_user_id', 'key': 'test_key',
+                                                              'token_scope': 'project', 'tenant_name': 'test_tenant',
+                                                              'tenant_domain_id': 'test_tenant_domain_id',
+                                                              'domain_name': 'test_domain'}),
+            ('3.x_oidc_access_token', OpenStackIdentity_3_0_MockHttp, {'user_id': 'test_user_id', 'key': 'test_key',
+                                                              'token_scope': 'domain', 'tenant_name': 'test_tenant',
+                                                              'tenant_domain_id': 'test_tenant_domain_id',
+                                                              'domain_name': 'test_domain'})
         ]
 
         user_id = OPENSTACK_PARAMS[0]
         key = OPENSTACK_PARAMS[1]
 
-        for (auth_version, mock_http_class) in tuples:
+        for (auth_version, mock_http_class, kwargs) in tuples:
             connection = \
                 self._get_mock_connection(mock_http_class=mock_http_class)
             auth_url = connection.auth_url
 
+            if not kwargs:
+                kwargs['user_id'] = user_id
+                kwargs['key'] = key
+
             cls = get_class_for_auth_version(auth_version=auth_version)
-            osa = cls(auth_url=auth_url, user_id=user_id, key=key,
-                      parent_conn=connection)
+            osa = cls(auth_url=auth_url, parent_conn=connection, **kwargs)
 
             self.assertEqual(osa.urls, {})
             self.assertIsNone(osa.auth_token)
@@ -131,10 +147,12 @@ class OpenStackIdentityConnectionTestCase(unittest.TestCase):
             self.assertTrue(len(osa.urls) >= 1)
             self.assertTrue(osa.auth_token is not None)
 
-            if auth_version in ['1.1', '2.0', '2.0_apikey', '2.0_password']:
+            if auth_version in ['1.1', '2.0', '2.0_apikey', '2.0_password',
+                                '3.x_password', '3.x_oidc_access_token']:
                 self.assertTrue(osa.auth_token_expires is not None)
 
-            if auth_version in ['2.0', '2.0_apikey', '2.0_password']:
+            if auth_version in ['2.0', '2.0_apikey', '2.0_password',
+                                '3.x_password', '3.x_oidc_access_token']:
                 self.assertTrue(osa.auth_user_info is not None)
 
     def test_token_expiration_and_force_reauthentication(self):
@@ -685,6 +703,22 @@ class OpenStackIdentity_3_0_MockHttp(MockHttp):
         if method == 'GET':
             body = self.fixtures.load('v3_projects.json')
             return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
+        raise NotImplementedError()
+
+    def _v3_OS_FEDERATION_identity_providers_test_user_id_protocols_test_tenant_auth(self, method, url, body, headers):
+        if method == 'GET':
+            if 'Authorization' not in headers:
+                return (httplib.UNAUTHORIZED, '', headers, httplib.responses[httplib.OK])
+
+            if headers['Authorization'] == 'Bearer test_key':
+                response_body = ComputeFileFixtures('openstack').load('_v3__auth.json')
+                response_headers = {
+                    'Content-Type': 'application/json',
+                    'x-subject-token': 'foo-bar'
+                }
+                return (httplib.OK, response_body, response_headers, httplib.responses[httplib.OK])
+
+            return (httplib.UNAUTHORIZED, '{}', headers, httplib.responses[httplib.OK])
         raise NotImplementedError()
 
     def _v3_auth_tokens(self, method, url, body, headers):

--- a/libcloud/test/common/test_openstack_identity.py
+++ b/libcloud/test/common/test_openstack_identity.py
@@ -51,13 +51,13 @@ class OpenStackIdentityConnectionTestCase(unittest.TestCase):
 
     def test_auth_url_is_correctly_assembled(self):
         tuples = [
-            ('1.0', OpenStackMockHttp),
-            ('1.1', OpenStackMockHttp),
-            ('2.0', OpenStack_2_0_MockHttp),
-            ('2.0_apikey', OpenStack_2_0_MockHttp),
-            ('2.0_password', OpenStack_2_0_MockHttp),
-            ('3.x_password', OpenStackIdentity_3_0_MockHttp),
-            ('3.x_oidc_access_token', OpenStackIdentity_3_0_MockHttp)
+            ('1.0', OpenStackMockHttp, {}),
+            ('1.1', OpenStackMockHttp, {}),
+            ('2.0', OpenStack_2_0_MockHttp, {}),
+            ('2.0_apikey', OpenStack_2_0_MockHttp, {}),
+            ('2.0_password', OpenStack_2_0_MockHttp, {}),
+            ('3.x_password', OpenStackIdentity_3_0_MockHttp, {'tenant_name': 'tenant-name'}),
+            ('3.x_oidc_access_token', OpenStackIdentity_3_0_MockHttp, {'tenant_name': 'tenant-name'})
         ]
 
         APPEND = 0
@@ -83,7 +83,7 @@ class OpenStackIdentityConnectionTestCase(unittest.TestCase):
         user_id = OPENSTACK_PARAMS[0]
         key = OPENSTACK_PARAMS[1]
 
-        for (auth_version, mock_http_class) in tuples:
+        for (auth_version, mock_http_class, kwargs) in tuples:
             for (url, should_append_default_path, expected_path) in auth_urls:
                 connection = \
                     self._get_mock_connection(mock_http_class=mock_http_class,
@@ -94,8 +94,8 @@ class OpenStackIdentityConnectionTestCase(unittest.TestCase):
                 osa = cls(auth_url=auth_url,
                           user_id=user_id,
                           key=key,
-                          tenant_name='tenant-name',
-                          parent_conn=connection)
+                          parent_conn=connection,
+                          **kwargs)
 
                 try:
                     osa = osa.authenticate()


### PR DESCRIPTION
## Fill auth_user_info in OpenStack v3 auth

### Description

When changing the OS_AUTH_VERSION to '3.x_password' instead of '2.0_password', we lose the user id information. This information is important to link for example snapshots to the user that made them.

This PR offers to restore the auth_user_info  when authenticate with OpenStackIdentity_3_0_Connection

### Status
ready for review

### Checklist (tick everything that applies)

- [ x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ x] Documentation
- [ x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
